### PR TITLE
Update OTP generator to use crypto.randomBytes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1805,11 +1805,6 @@
         "@types/superagent": "*"
       }
     },
-    "@types/validator": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.3.tgz",
-      "integrity": "sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w=="
-    },
     "@types/yargs": {
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
@@ -8727,9 +8722,15 @@
           "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.11.1.tgz",
           "integrity": "sha512-6CGdjwJLmKw+sQbK5ZDo1v1yTajkqfPOUDWSYVIlhUiCh6Phy8sAnMFE2XKHAcKAdoOz4jJUQhjPQWPYUuHxrA==",
           "requires": {
-            "@types/validator": "10.11.3",
             "google-libphonenumber": "^3.1.6",
             "validator": "12.0.0"
+          },
+          "dependencies": {
+            "validator": {
+              "version": "12.0.0",
+              "resolved": "https://registry.npmjs.org/validator/-/validator-12.0.0.tgz",
+              "integrity": "sha512-r5zA1cQBEOgYlesRmSEwc9LkbfNLTtji+vWyaHzRZUxCTHdsX3bd+sdHfs5tGZ2W6ILGGsxWxCNwT/h3IY/3ng=="
+            }
           }
         },
         "dd-trace": {
@@ -10685,11 +10686,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "validator": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-12.0.0.tgz",
-      "integrity": "sha512-r5zA1cQBEOgYlesRmSEwc9LkbfNLTtji+vWyaHzRZUxCTHdsX3bd+sdHfs5tGZ2W6ILGGsxWxCNwT/h3IY/3ng=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       "ts"
     ],
     "rootDir": "test",
-    "testRegex": ".e2e-spec.ts$",
+    "testRegex": ".(e2e-spec|spec).ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/src/escrow/add.dto.ts
+++ b/src/escrow/add.dto.ts
@@ -1,6 +1,6 @@
 import { IsString, IsNotEmptyObject, IsEnum } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { PluginTypeEnum } from '../plugins/plugin.type.enum'
+import { PluginTypeEnum } from '../plugins/plugin.type.enum';
 
 /**
  * DTO for the add endpoint

--- a/src/escrow/create.dto.ts
+++ b/src/escrow/create.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmptyObject, IsEnum, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { PluginTypeEnum } from '../plugins/plugin.type.enum'
+import { PluginTypeEnum } from '../plugins/plugin.type.enum';
 
 /**
  * DTO for the create endpoint

--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -32,8 +32,13 @@ export class EscrowService {
             const walletCredentials = await this.fetchWalletCredentials(result.id);
 
             // TODO we need to save the admin api key and then we can pass it along here
-            // tslint:disable-next-line:max-line-length
-            const data = await this.spinUpAgent(walletCredentials.wallet_id, walletCredentials.wallet_key, walletCredentials.wallet_key, walletCredentials.seed, walletCredentials.did);
+            const data = await this.spinUpAgent(
+                walletCredentials.wallet_id,
+                walletCredentials.wallet_key,
+                walletCredentials.wallet_key,
+                walletCredentials.seed,
+                walletCredentials.did
+            );
             Logger.log(`Spun up agent for did ${walletCredentials.did}`, data);
             // Append the connection data onto the result
             result.connectionData = data.connectionData;
@@ -67,7 +72,13 @@ export class EscrowService {
         Logger.log(`Saved wallet credentials for did ${walletCredentials.did}`);
 
         // TODO we need to save the admin api key and then we can pass it along here
-        const data = await this.spinUpAgent(walletCredentials.wallet_id, walletCredentials.wallet_key, walletCredentials.wallet_key, walletCredentials.seed, walletCredentials.did);
+        const data = await this.spinUpAgent(
+            walletCredentials.wallet_id,
+            walletCredentials.wallet_key,
+            walletCredentials.wallet_key,
+            walletCredentials.seed,
+            walletCredentials.did
+        );
         Logger.log(`Spun up agent for did ${walletCredentials.did}`);
 
         return { id: walletCredentials.did, connectionData: data.connectionData };

--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -36,7 +36,7 @@ export class EscrowService {
             const data = await this.spinUpAgent(walletCredentials.wallet_id, walletCredentials.wallet_key, walletCredentials.wallet_key, walletCredentials.seed, walletCredentials.did);
             Logger.log(`Spun up agent for did ${walletCredentials.did}`, data);
             // Append the connection data onto the result
-            result.connectionData = data.connectionData
+            result.connectionData = data.connectionData;
         }
         return result;
     }

--- a/src/escrow/verify.dto.ts
+++ b/src/escrow/verify.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmptyObject, IsEnum } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { PluginTypeEnum } from '../plugins/plugin.type.enum'
+import { PluginTypeEnum } from '../plugins/plugin.type.enum';
 
 /**
  * DTO for the verify endpoint

--- a/src/sms/sms.service.ts
+++ b/src/sms/sms.service.ts
@@ -65,7 +65,7 @@ export class SmsService {
         if (filters.govId1) {
             search = { gov_id_1_hash: SecurityUtility.hash32(filters.govId1 + process.env.HASH_PEPPER) };
         } else {
-            search = { gov_id_2_hash: SecurityUtility.hash32(filters.govId2 + process.env.HASH_PEPPER) }
+            search = { gov_id_2_hash: SecurityUtility.hash32(filters.govId2 + process.env.HASH_PEPPER) };
         }
         const results = await this.smsOtpRepository.find(search);
         if (results.length < 1) {
@@ -81,7 +81,7 @@ export class SmsService {
     private async generateOtp(smsOtpEntity: SmsOtp): Promise<number> {
         const otp = this.twillioService.generateRandomOtp();
         const otpExpireTime = new Date(Date.now() + 15000); // 15 min
-        smsOtpEntity.otp = otp
+        smsOtpEntity.otp = otp;
         smsOtpEntity.otp_expiration_time = otpExpireTime;
         await this.smsOtpRepository.save(smsOtpEntity);
         this.scheduleOtpExpiration(smsOtpEntity);
@@ -117,7 +117,7 @@ export class SmsService {
     public scheduleOtpExpiration(smsOtpEntity: SmsOtp): void {
         setTimeout(
             async () => {
-                smsOtpEntity.otp = null
+                smsOtpEntity.otp = null;
                 smsOtpEntity.otp_expiration_time = null;
                 await this.smsOtpRepository.save(smsOtpEntity);
             },

--- a/src/sms/twillio.service.ts
+++ b/src/sms/twillio.service.ts
@@ -5,7 +5,7 @@ import { ProtocolErrorCode } from 'protocol-common/protocol.errorcode';
 import { Constants } from 'protocol-common/constants';
 import { SmsErrorCode } from './sms.errorcode';
 import { default as twilio } from 'twilio';
-import crypto from "crypto";
+import crypto from 'crypto';
 
 /**
  * Putting Twillio in it's own service in case we want to support other SMS services

--- a/test/sms.twillio.service.spec.ts
+++ b/test/sms.twillio.service.spec.ts
@@ -1,0 +1,15 @@
+import { TwillioService } from '../src/sms/twillio.service';
+
+describe ('SMS Twillio Service', () => {
+
+    const service: TwillioService = new TwillioService();
+
+    // Note: This is a probabilistic test and does not guarantee the behavior of the function
+    it('generateRandomOtp() should generate valid OTPs', () => {
+        for (let i = 0; i < 10000; i++) {
+            const otp: number = service.generateRandomOtp();
+            expect(otp).toBeGreaterThan(99999); // Must be at least 6 digits
+            expect(otp).toBeLessThan(1000000); // Must be no more than 6 digits
+        }
+    });
+});

--- a/tslint.json
+++ b/tslint.json
@@ -7,48 +7,51 @@
         "no-unused-expression": true
     },
     "rules": {
-        "eofline": false,
-        "no-consecutive-blank-lines": false,
-        "quotemark": [
-            true,
-            "single"
-        ],
-        "indent": false,
-        "member-access": [
+        "array-type": [
             false
         ],
-        "ordered-imports": [
+        "arrow-parens": false,
+        "curly": false,
+        "eofline": false,
+        "indent": false,
+        "interface-name": [
+            false
+        ],
+        "max-classes-per-file": [
             false
         ],
         "max-line-length": [
             true,
             150
         ],
+        "member-access": [
+            false
+        ],
         "member-ordering": [
             false
         ],
-        "curly": false,
-        "interface-name": [
-            false
-        ],
-        "array-type": [
-            false
-        ],
-        "no-empty-interface": false,
+        "no-consecutive-blank-lines": false,
         "no-empty": false,
-        "arrow-parens": false,
-        "object-literal-sort-keys": false,
+        "no-empty-interface": false,
         "no-unused-expression": false,
-        "max-classes-per-file": [
-            false
-        ],
-        "variable-name": [
-            false
-        ],
+        "object-literal-sort-keys": false,
         "one-line": [
             false
         ],
         "one-variable-per-declaration": [
+            false
+        ],
+        "ordered-imports": [
+            false
+        ],
+        "quotemark": [
+            true,
+            "single"
+        ],
+        "semicolon": [
+            true
+        ],
+        "variable-name": [
             false
         ]
     },


### PR DESCRIPTION
This is the same change from protocol (https://github.com/kiva/protocol/pull/726) duplicated here.

Changes:
    * Changed OTP generator to use an evenly-distributed RNG between the needed 6-digit bounds (100000 - 999999).
    * Add a test to probabilistically assert the behavior.
    * Update jest configuration to support 'spec' in addition to 'e2e-spec'.
    * Update tslint to require semicolons

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>