### PR TITLE
Update circle ci docker-compose to specify network name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,11 @@ jobs:
           name: run linter
           command: |
             npm run lint
-      - run: docker-compose -f docker-compose.ci.yml build
       - run:
           name: Start docker compose and wait for readiness
           command: |
+            docker network ls
+            docker-compose -f docker-compose.ci.yml build
             set -x
             docker-compose -f docker-compose.ci.yml up -d
             sleep 150

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Start docker compose and wait for readiness
           command: |
-            docker ps
+            docker network prune
             docker network ls
             docker-compose -f docker-compose.ci.yml build
             set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Start docker compose and wait for readiness
           command: |
-            docker network prune
+            docker network prune -f
             docker network ls
             docker-compose -f docker-compose.ci.yml build
             set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
       - run:
           name: Start docker compose and wait for readiness
           command: |
+            docker ps
             docker network ls
             docker-compose -f docker-compose.ci.yml build
             set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
           name: Start docker compose and wait for readiness
           command: |
             docker network prune -f
-            docker network ls
             docker-compose -f docker-compose.ci.yml build
             set -x
             docker-compose -f docker-compose.ci.yml up -d

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,7 +4,12 @@ version: '3.5'
 
 networks:
   agency-network:
-    external: true
+    name: agency-network
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.0.0.0/24
 
 services:
   aries-key-guardian:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,12 +4,7 @@ version: '3.5'
 
 networks:
   agency-network:
-    name: agency-network
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 10.0.0.0/24
+    external: true
 
 services:
   aries-key-guardian:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,6 +4,7 @@ version: '3.5'
 
 networks:
   agency-network:
+    name: agency-network
     driver: bridge
     ipam:
       driver: default


### PR DESCRIPTION
Update circle ci docker-compose to specify network name, like in `aries-guardianship-agency`.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>