### PR TITLE
Environment Variable Change for Guardian-Bio-Auth

### DIFF
--- a/src/config/env.json
+++ b/src/config/env.json
@@ -4,7 +4,7 @@
     "DD_AGENT_HOST": "datadog-statsd.datadog",
     "DD_TRACE_AGENT_HOSTNAME": "datadog-statsd.datadog",
     "DD_TRACE_AGENT_PORT": 8126,
-    "IDENTITY_SERVICE_BACKEND": "ncratemplate",
+    "IDENTITY_SERVICE_BACKEND": "template",
     "IDENTITY_SERVICE_URL": "http://protocol-identity-service:3005",
     "JAEGER_ENDPOINT": "http://jaeger-collector:14268/api/traces",
     "JWT_EXPIRE_SECONDS": 36000,


### PR DESCRIPTION
Change backend from ncratemplate to template to integrate with the new guardian-bio-auth repo. Needed in order to integrate with guardian-bio-auth.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>