### PR TITLE
Fix bug where Twillio was disabled in remote envs

### DIFF
--- a/src/remote/remote.module.ts
+++ b/src/remote/remote.module.ts
@@ -17,7 +17,9 @@ import { SmsDisabledService } from './impl/sms.disabled.service';
         useClass: AgencyService
     }, {
         provide: ISmsService,
-        useClass: process.env.TWILLIO_ENABLED === 'true' ? SmsTwillioService : SmsDisabledService
+        useFactory: () => {
+            return process.env.TWILLIO_ENABLED === 'true' ? new SmsTwillioService() : new SmsDisabledService();
+        }
     }],
     exports: [IIdentityService, IAgencyService, ISmsService]
 })


### PR DESCRIPTION
@jeffk-kiva you'll like this one :) 
Essentially the way that we load env.json values into process.env values is in the ConfigModule which is executed almost immediately, but not before the all Modules have been loaded. Because this referenced process.env as part of the top level module loading it executed before the ConfigModule had a change to update the process.env value. Moving it to a factory makes it so that it executes the function after all the modules have been loaded and after the ConfigModule has done it's thing. Yay env variables!
https://kiva.atlassian.net/browse/PRO-2453
Signed-off-by: Jacob Saur <jsaur@kiva.org>