### PR TITLE
PRO-2588: Add support for verifying via fingerprint template

### DIFF
--- a/src/plugins/dto/verify.fingerprint.image.dto.ts
+++ b/src/plugins/dto/verify.fingerprint.image.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class VerifyFingerprintImageDto {
+
+    @ApiProperty({
+        description: 'Finger position of the fingerprint template'
+    })
+    @IsNotEmpty() readonly position: number;
+
+    @ApiProperty({
+        description: 'Base 64 representation of the fingerprint image'
+    })
+    @IsNotEmpty() @IsString() readonly image: string;
+
+    static isInstance(objToCheck: any): objToCheck is VerifyFingerprintImageDto {
+        const dto: VerifyFingerprintImageDto = objToCheck as VerifyFingerprintImageDto;
+        return dto !== undefined && dto.position !== undefined && dto.image !== undefined;
+    }
+}

--- a/src/plugins/dto/verify.fingerprint.template.dto.ts
+++ b/src/plugins/dto/verify.fingerprint.template.dto.ts
@@ -1,0 +1,20 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VerifyFingerprintTemplateDto {
+
+    @ApiProperty({
+        description: 'Finger position of the fingerprint template'
+    })
+    @IsNotEmpty() readonly position: number;
+
+    @ApiProperty({
+        description: 'Base 64 representation of the fingerprint template'
+    })
+    @IsNotEmpty() @IsString() readonly template: string;
+
+    static isInstance(objToCheck: any): objToCheck is VerifyFingerprintTemplateDto {
+        const dto: VerifyFingerprintTemplateDto = objToCheck as VerifyFingerprintTemplateDto;
+        return dto !== undefined && dto.position !== undefined && dto.template !== undefined;
+    }
+}

--- a/src/plugins/impl/fingerprint.plugin.ts
+++ b/src/plugins/impl/fingerprint.plugin.ts
@@ -20,26 +20,26 @@ export class FingerprintPlugin implements IPlugin {
      */
     public async verify(filters: any, params: VerifyFingerprintImageDto | VerifyFingerprintTemplateDto) {
         let response;
-        if (VerifyFingerprintImageDto.isInstance(params)) {
-            try {
+        try {
+            if (VerifyFingerprintImageDto.isInstance(params)) {
                 response = await this.identityService.verifyFingerprint(params.position, params.image, filters);
-            } catch(e) {
-                // Handle specific error codes
-                switch (e.code) {
-                    case 'FINGERPRINT_NO_MATCH':
-                    case 'FINGERPRINT_MISSING_NOT_CAPTURED':
-                    case 'FINGERPRINT_MISSING_AMPUTATION':
-                    case 'FINGERPRINT_MISSING_UNABLE_TO_PRINT':
-                        if (process.env.QUALITY_CHECK_ENABLED === 'true') {
-                            e = await this.fingerprintQualityCheck(e, filters);
-                        }
-                    // no break, fall through
-                    default:
-                        throw e;
-                }
+            } else {
+                response = await this.identityService.verifyFingerprintTemplate(params.position, params.template, filters);
             }
-        } else {
-            response = await this.identityService.verifyFingerprintTemplate(params.position, params.template, filters);
+        } catch(e) {
+            // Handle specific error codes
+            switch (e.code) {
+                case 'FINGERPRINT_NO_MATCH':
+                case 'FINGERPRINT_MISSING_NOT_CAPTURED':
+                case 'FINGERPRINT_MISSING_AMPUTATION':
+                case 'FINGERPRINT_MISSING_UNABLE_TO_PRINT':
+                    if (process.env.QUALITY_CHECK_ENABLED === 'true') {
+                        e = await this.fingerprintQualityCheck(e, filters);
+                    }
+                // no break, fall through
+                default:
+                    throw e;
+            }
         }
 
         //  The identity service should throw this error on no match, but just to be safe double check it and throw here

--- a/src/remote/identity.service.interface.ts
+++ b/src/remote/identity.service.interface.ts
@@ -1,5 +1,6 @@
 export abstract class IIdentityService {
-    abstract async verify(position: number, image: string, filters: any): Promise<any>;
+    abstract async verifyFingerprint(position: number, image: string, filters: any): Promise<any>;
+    abstract async verifyFingerprintTemplate(position: number, template: string, filters: any): Promise<any>;
     abstract async templatize(data: any): Promise<any>;
     abstract async qualityCheck(filters: any): Promise<any>;
 }

--- a/src/remote/impl/identity.service.ts
+++ b/src/remote/impl/identity.service.ts
@@ -25,7 +25,7 @@ export class IdentityService implements IIdentityService {
     /**
      * TODO right now this keeps the identity service url the same, we probably want to change that so it better matches our plugin pattern
      */
-    public async verify(position: number, image: string, filters: any): Promise<any> {
+    public async verifyFingerprint(position: number, image: string, filters: any): Promise<any> {
         const request: AxiosRequestConfig = {
             method: 'POST',
             url: this.baseUrl + '/api/v1/verify',
@@ -34,6 +34,21 @@ export class IdentityService implements IIdentityService {
                 position,
                 image,
                 filters,
+            },
+        };
+        return this.http.requestWithRetry(request);
+    }
+
+    public async verifyFingerprintTemplate(position: number, template: string, filters: any): Promise<any> {
+        const request: AxiosRequestConfig = {
+            method: 'POST',
+            url: this.baseUrl + '/api/v1/verify',
+            data: {
+                backend: this.backend,
+                position,
+                image: template,
+                filters,
+                imageType: 'TEMPLATE',
             },
         };
         return this.http.requestWithRetry(request);

--- a/test/e2e/escrow.fingerprint.e2e-spec.ts
+++ b/test/e2e/escrow.fingerprint.e2e-spec.ts
@@ -77,10 +77,28 @@ describe('EscrowController (e2e) using fingerprint plugin', () => {
         await app.init();
     });
 
-    it('Verify endpoint', () => {
+    it('Verify endpoint (fingerprint image)', () => {
         return request(app.getHttpServer())
             .post('/v1/escrow/verify')
             .send(body)
+            .expect(201)
+            .then((res) => {
+                assert.equal(res.body.status, 'matched');
+                assert.equal(res.body.id, 'agentId123');
+            });
+    });
+
+    it('Verify endpoint (fingerprint template)', () => {
+        const templateBody = {
+            ...body,
+            params: {
+                ...body.params,
+                template: 'base64_encoded_template'
+            }
+        };
+        return request(app.getHttpServer())
+            .post('/v1/escrow/verify')
+            .send(templateBody)
             .expect(201)
             .then((res) => {
                 assert.equal(res.body.status, 'matched');

--- a/test/e2e/escrow.fingerprint.e2e-spec.ts
+++ b/test/e2e/escrow.fingerprint.e2e-spec.ts
@@ -92,7 +92,7 @@ describe('EscrowController (e2e) using fingerprint plugin', () => {
         const templateBody = {
             ...body,
             params: {
-                ...body.params,
+                position: 1,
                 template: 'base64_encoded_template'
             }
         };

--- a/test/mock/mock.identity.service.ts
+++ b/test/mock/mock.identity.service.ts
@@ -8,7 +8,16 @@ export class MockIdentityService implements IIdentityService {
         return Promise.resolve(undefined);
     }
 
-    async verify(position: number, image: string, filters: any): Promise<any> {
+    async verifyFingerprint(position: number, image: string, filters: any): Promise<any> {
+        return Promise.resolve({
+            data: {
+                status: this.status,
+                did: this.did,
+            },
+        });
+    }
+
+    async verifyFingerprintTemplate(position: number, template: string, filters: any): Promise<any> {
         return Promise.resolve({
             data: {
                 status: this.status,


### PR DESCRIPTION
Currently, only verifying via fingerprint image is supported. If we're going to push templating into the client, then we need to support verifying via template.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>