### PR TITLE
PRO-2632: Adding new plugins shouldn't throw an error

### DIFF
--- a/src/db/external.id.service.ts
+++ b/src/db/external.id.service.ts
@@ -74,4 +74,41 @@ export class ExternalIdService {
         }
         return this.externalIdRepository.save(externalIds);
     }
+
+    private async getOrCreateExternalId(externalId: ExternalId): Promise<ExternalId> {
+        const dbExternalId = await this.externalIdRepository.findOne({
+            did: externalId.did,
+            external_id: externalId.external_id,
+            external_id_type: externalId.external_id_type
+        });
+        return dbExternalId ?? await this.externalIdRepository.save(externalId);
+    }
+
+    public async getOrCreateExternalIds(did: string, filters: CreateFiltersDto): Promise<Array<ExternalId>> {
+        const externalIds: ExternalId[] = Array.from(filters.externalIds?.entries() ?? []).map((entry: [string, string]) => {
+            const externalId = new ExternalId();
+            externalId.did = did;
+            externalId.external_id = entry[1];
+            externalId.external_id_type = entry[0];
+            return externalId;
+        });
+        // TODO: Remove these two checks once we've removed the deprecated code (PRO-2676)
+        if (filters.govId1 || filters.nationalId) {
+            const idValue: string = filters.govId1 ?? filters.nationalId;
+            const externalId1 = new ExternalId();
+            externalId1.did = did;
+            externalId1.external_id = SecurityUtility.hash32(idValue + process.env.HASH_PEPPER);
+            externalId1.external_id_type = 'sl_national_id'; // TODO: update to be specifiable by the filters
+            externalIds.push(externalId1);
+        }
+        if (filters.govId2 || filters.voterId) {
+            const idValue: string = filters.govId2 ?? filters.voterId;
+            const externalId2 = new ExternalId();
+            externalId2.did = did;
+            externalId2.external_id = SecurityUtility.hash32(idValue + process.env.HASH_PEPPER);
+            externalId2.external_id_type = 'sl_voter_id'; // TODO: update to be specifiable by the filters
+            externalIds.push(externalId2);
+        }
+        return Promise.all(externalIds.map((externalId: ExternalId) => this.getOrCreateExternalId(externalId)));
+    }
 }

--- a/src/escrow/escrow.service.ts
+++ b/src/escrow/escrow.service.ts
@@ -127,7 +127,7 @@ export class EscrowService {
             throw new ProtocolException(ProtocolErrorCode.VALIDATION_EXCEPTION, 'Can\'t update escrow service, the id doesn\'t exist');
         }
 
-        await this.externalIdService.createExternalIds(id, filters);
+        await this.externalIdService.getOrCreateExternalIds(id, filters);
 
         const plugin = this.pluginFactory.create(pluginType);
         await plugin.save(id, params);

--- a/src/remote/impl/identity.service.ts
+++ b/src/remote/impl/identity.service.ts
@@ -78,7 +78,7 @@ export class IdentityService implements IIdentityService {
     public async qualityCheck(id: string): Promise<any> {
         const request: AxiosRequestConfig = {
             method: 'GET',
-            url: this.baseUrl + '/api/v1/positions/' + this.backend + `/did=${id}`,
+            url: this.baseUrl + '/api/v1/positions/' + this.backend + `/dids=${id}`,
         };
         return this.http.requestWithRetry(request);
     }


### PR DESCRIPTION
If you add a new plugin (e.g. a new fingerprint to verify with), you will probably use the same did + external_id (e.g. the same national ID) as you used for the previous plugins. Therefore, maybe obviously, the /add route needs only insert a new external id if one already exists. Previously, because of a uniqueness constraint on external_id + external_id_type, that would throw an error.

Also, fix the call to identity service, which should use the `dids` filter instead of `did`.