### PR TITLE
PRO-2696: Add support for multiple dids being sent to Identity Service

### DIFF
--- a/src/db/external.id.service.ts
+++ b/src/db/external.id.service.ts
@@ -52,7 +52,7 @@ export class ExternalIdService {
         const externalIds: ExternalId[] = Array.from(filters.externalIds?.entries() ?? []).map((entry: [string, string]) => {
             const externalId = new ExternalId();
             externalId.did = did;
-            externalId.external_id = entry[1];
+            externalId.external_id = SecurityUtility.hash32(entry[1] + process.env.HASH_PEPPER);
             externalId.external_id_type = entry[0];
             return externalId;
         });
@@ -89,7 +89,7 @@ export class ExternalIdService {
         const externalIds: ExternalId[] = Array.from(filters.externalIds?.entries() ?? []).map((entry: [string, string]) => {
             const externalId = new ExternalId();
             externalId.did = did;
-            externalId.external_id = entry[1];
+            externalId.external_id = SecurityUtility.hash32(entry[1] + process.env.HASH_PEPPER);
             externalId.external_id_type = entry[0];
             return externalId;
         });

--- a/src/db/external.id.service.ts
+++ b/src/db/external.id.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ExternalId } from './entity/external.id';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { SecurityUtility } from 'protocol-common/security.utility';
 import { ProtocolException } from 'protocol-common/protocol.exception';
 import { ProtocolErrorCode } from 'protocol-common/protocol.errorcode';
@@ -16,35 +16,36 @@ export class ExternalIdService {
         private readonly externalIdRepository: Repository<ExternalId>
     ) {}
 
-    public async fetchExternalId(filters: VerifyFiltersDto): Promise<ExternalId> {
-        let externalIdValue: string;
+    public async fetchExternalIds(filters: VerifyFiltersDto): Promise<ExternalId[]> {
+        let idValues: string;
         let externalIdType: string;
         if (filters.externalId && filters.externalIdType) {
-            externalIdValue = filters.externalId;
+            idValues = filters.externalId;
             externalIdType = filters.externalIdType;
         } else if (filters.govId1 || filters.nationalId) {
             // TODO: Remove this check once we've removed the deprecated code (PRO-2676)
-            const idValue: string = filters.govId1 ?? filters.nationalId;
-            externalIdValue = SecurityUtility.hash32(idValue + process.env.HASH_PEPPER);
+            idValues = filters.govId1 ?? filters.nationalId;
             externalIdType = 'sl_national_id';
         } else if (filters.govId2 || filters.voterId) {
             // TODO: Remove this check once we've removed the deprecated code (PRO-2676)
-            const idValue: string = filters.govId2 ?? filters.voterId;
-            externalIdValue = SecurityUtility.hash32(idValue + process.env.HASH_PEPPER);
+            idValues = filters.govId2 ?? filters.voterId;
             externalIdType = 'sl_voter_id';
         } else {
             throw new ProtocolException(ProtocolErrorCode.NO_CITIZEN_FOUND, 'No external ID provided to look up a DID');
         }
+        const externalIdValues: string[] = idValues.split(',').map((idValue: string) => {
+            return SecurityUtility.hash32(idValue + process.env.HASH_PEPPER);
+        });
 
         // If we make it this far, we have something to look up
-        const externalId: ExternalId | undefined = await this.externalIdRepository.findOne({
-            external_id: externalIdValue,
+        const externalIds: ExternalId[] = await this.externalIdRepository.find({
+            external_id: In(externalIdValues),
             external_id_type: externalIdType
         });
-        if (!externalId) {
-            throw new ProtocolException(ProtocolErrorCode.NO_CITIZEN_FOUND, `Cannot find a DID for ${externalIdType}: ${externalIdValue}`);
+        if (externalIds.length === 0) {
+            throw new ProtocolException(ProtocolErrorCode.NO_CITIZEN_FOUND, `Cannot find a DID for ${externalIdType}: ${idValues}`);
         }
-        return externalId;
+        return externalIds;
     }
 
     public async createExternalIds(did: string, filters: CreateFiltersDto): Promise<Array<ExternalId>> {

--- a/src/remote/identity.service.interface.ts
+++ b/src/remote/identity.service.interface.ts
@@ -1,6 +1,6 @@
 export abstract class IIdentityService {
-    abstract verifyFingerprint(position: number, image: string, did: string): Promise<any>;
-    abstract verifyFingerprintTemplate(position: number, template: string, did: string): Promise<any>;
+    abstract verifyFingerprint(position: number, image: string, dids: string): Promise<any>;
+    abstract verifyFingerprintTemplate(position: number, template: string, dids: string): Promise<any>;
     abstract templatize(data: any): Promise<any>;
-    abstract qualityCheck(id: string): Promise<any>;
+    abstract qualityCheck(dids: string): Promise<any>;
 }

--- a/src/remote/impl/identity.service.ts
+++ b/src/remote/impl/identity.service.ts
@@ -23,9 +23,14 @@ export class IdentityService implements IIdentityService {
     }
 
     /**
+     * Send a request to IdentityService to verify a fingerprint image.
      * TODO right now this keeps the identity service url the same, we probably want to change that so it better matches our plugin pattern
+     *
+     * @param position The position of the finger that the fingerprint template refers to.
+     * @param image The image of the fingerprint.
+     * @param dids A comma-separated list of dids that the fingerprint template may correspond to.
      */
-    public async verifyFingerprint(position: number, image: string, did: string): Promise<any> {
+    public async verifyFingerprint(position: number, image: string, dids: string): Promise<any> {
         const request: AxiosRequestConfig = {
             method: 'POST',
             url: this.baseUrl + '/api/v1/verify',
@@ -34,14 +39,21 @@ export class IdentityService implements IIdentityService {
                 position,
                 image,
                 filters: {
-                    dids: did
+                    dids
                 },
             },
         };
         return this.http.requestWithRetry(request);
     }
 
-    public async verifyFingerprintTemplate(position: number, template: string, did: string): Promise<any> {
+    /**
+     * Send a request to IdentityService to verify a fingerprint template.
+     *
+     * @param position The position of the finger that the fingerprint template refers to.
+     * @param template The template of the fingerprint.
+     * @param dids A comma-separated list of dids that the fingerprint template may correspond to.
+     */
+    public async verifyFingerprintTemplate(position: number, template: string, dids: string): Promise<any> {
         const request: AxiosRequestConfig = {
             method: 'POST',
             url: this.baseUrl + '/api/v1/verify',
@@ -50,7 +62,7 @@ export class IdentityService implements IIdentityService {
                 position,
                 image: template,
                 filters: {
-                    dids: did
+                    dids
                 },
                 imageType: 'TEMPLATE',
             },
@@ -75,10 +87,10 @@ export class IdentityService implements IIdentityService {
      * Queries the identity service to get the finger positions with the best quality scores
      * TODO the identity service should update the positions endpoint to accept data in the body instead of via url params
      */
-    public async qualityCheck(id: string): Promise<any> {
+    public async qualityCheck(dids: string): Promise<any> {
         const request: AxiosRequestConfig = {
             method: 'GET',
-            url: this.baseUrl + '/api/v1/positions/' + this.backend + `/dids=${id}`,
+            url: this.baseUrl + '/api/v1/positions/' + this.backend + `/dids=${dids}`,
         };
         return this.http.requestWithRetry(request);
     }

--- a/src/sms/sms.service.ts
+++ b/src/sms/sms.service.ts
@@ -35,8 +35,11 @@ export class SmsService {
      */
     public async verify(filters: VerifyFiltersDto, params: SmsParamsDto): Promise<{ status, id }> {
 
-        const externalId: ExternalId = await this.externalIdService.fetchExternalId(filters);
-        const did: string = externalId.did;
+        const externalIds: ExternalId[] = await this.externalIdService.fetchExternalIds(filters);
+        if (externalIds.length > 1) {
+            throw new ProtocolException(ProtocolErrorCode.DUPLICATE_ENTRY, 'Provided filters did not uniquely identity a did');
+        }
+        const did: string = externalIds[0].did;
 
         await this.rateLimit(did, params);
 

--- a/test/e2e/escrow.sms.e2e-spec.ts
+++ b/test/e2e/escrow.sms.e2e-spec.ts
@@ -24,6 +24,7 @@ import { ExternalId } from '../../src/db/entity/external.id';
 import { FindConditions } from 'typeorm/find-options/FindConditions';
 import { FindOneOptions } from 'typeorm/find-options/FindOneOptions';
 import { ExternalIdService } from '../../src/db/external.id.service';
+import { FindOperator } from 'typeorm';
 
 /**
  * This mocks out external dependencies (eg Twillio, DB)
@@ -73,7 +74,12 @@ describe('EscrowController (e2e) using SMS plugin', () => {
         const mockExternalIdRepository = new class extends MockRepository<ExternalId> {
 
             externalIdFilter(externalId: ExternalId, conditions?: FindConditions<ExternalId>): boolean {
-                return conditions.external_id === externalId.external_id && conditions.external_id_type === externalId.external_id_type;
+                // @ts-ignore
+                const values: string[] = conditions.external_id instanceof FindOperator && conditions.external_id.type === 'in' ?
+                    conditions.external_id.value :
+                    [conditions.external_id];
+                return values.some((value: string) => value === externalId.external_id) &&
+                    conditions.external_id_type === externalId.external_id_type;
             }
 
             async findOne(conditions?: FindConditions<ExternalId>, options?: FindOneOptions<ExternalId>): Promise<ExternalId | undefined> {

--- a/test/mock/mock.identity.service.ts
+++ b/test/mock/mock.identity.service.ts
@@ -8,7 +8,7 @@ export class MockIdentityService implements IIdentityService {
         return Promise.resolve(undefined);
     }
 
-    async verifyFingerprint(position: number, image: string, id: string): Promise<any> {
+    async verifyFingerprint(position: number, image: string, dids: string): Promise<any> {
         return Promise.resolve({
             data: {
                 status: this.status,
@@ -17,7 +17,7 @@ export class MockIdentityService implements IIdentityService {
         });
     }
 
-    async verifyFingerprintTemplate(position: number, template: string, id: string): Promise<any> {
+    async verifyFingerprintTemplate(position: number, template: string, dids: string): Promise<any> {
         return Promise.resolve({
             data: {
                 status: this.status,
@@ -26,7 +26,7 @@ export class MockIdentityService implements IIdentityService {
         });
     }
 
-    async qualityCheck(id: string): Promise<any> {
+    async qualityCheck(dids: string): Promise<any> {
         return Promise.resolve({
             data: [1]
         });


### PR DESCRIPTION
V2 integration tests highlighted that filters may include multiple voter IDs or national IDs as a comma-separated list, which may in turn refer to multiple DIDs. These multiple DIDs should be passed on to Identity Service.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>