### PR TITLE
PRO-2665: ExternalId roll forward + deserialization bugfix

### DIFF
--- a/src/escrow/dto/create.filters.dto.ts
+++ b/src/escrow/dto/create.filters.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsNotEmptyObject, IsOptional } from 'class-validator';
 
-export abstract class CreateFiltersDto {
+export class CreateFiltersDto {
 
     @ApiProperty({
         description: 'DEPRECATED. A hardcoded id that could be provided. Maps to type "sl_national_id".'
@@ -24,7 +24,19 @@ export abstract class CreateFiltersDto {
     @IsOptional() @IsNotEmpty() readonly govId2: string | undefined;
 
     @ApiProperty({
-        description: 'A list of any number of IDs related to a particular DID.'
+        description: 'An object containing any number of IDs related to a particular DID, as long as they all refer to the same DID.'
     })
-    @IsOptional() @IsNotEmptyObject() readonly externalIds: Map<string, string>;
+    @IsOptional() @IsNotEmptyObject() readonly externalIds: object;
+
+    // TODO: Remove this in favor of externalIds once we've removed the deprecated code (PRO-2676)
+    public static getIds(filters: CreateFiltersDto): Map<string, string> {
+        const ids: Map<string, string> = new Map<string, string>(Object.entries(filters.externalIds ?? {}));
+        if (filters.govId1 || filters.nationalId) {
+            ids.set('sl_national_id', filters.govId1 ?? filters.nationalId);
+        }
+        if (filters.govId2 || filters.voterId) {
+            ids.set('sl_voter_id', filters.govId2 ?? filters.voterId);
+        }
+        return ids;
+    }
 }

--- a/src/plugins/dto/verify.filters.dto.ts
+++ b/src/plugins/dto/verify.filters.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional } from 'class-validator';
+import { IsNotEmpty, IsNotEmptyObject, IsOptional } from 'class-validator';
 
 export class VerifyFiltersDto {
 
@@ -24,12 +24,19 @@ export class VerifyFiltersDto {
     @IsOptional() @IsNotEmpty() readonly govId2: string | undefined;
 
     @ApiProperty({
-        description: 'Type of external ID to filter on. E.g. "sl_national_id"'
+        description: 'An object containing any number of IDs related to a particular DID, as long as they all refer to the same DID.'
     })
-    @IsOptional() @IsNotEmpty() readonly externalIdType: string | undefined;
+    @IsOptional() @IsNotEmptyObject() readonly externalIds: object;
 
-    @ApiProperty({
-        description: 'Value of external ID to filter on. E.g. "NIN11111"'
-    })
-    @IsOptional() @IsNotEmpty() readonly externalId: string | undefined;
+    // TODO: Remove this in favor of just using externalIds once we've removed the deprecated code (PRO-2676)
+    static getIds(filters: VerifyFiltersDto): Map<string, string> {
+        const ids: Map<string, string> = new Map<string, string>(Object.entries(filters.externalIds ?? {}));
+        if (filters.govId1 || filters.nationalId) {
+            ids.set('sl_national_id', filters.govId1 ?? filters.nationalId);
+        }
+        if (filters.govId2 || filters.voterId) {
+            ids.set('sl_voter_id', filters.govId2 ?? filters.voterId);
+        }
+        return ids;
+    }
 }

--- a/src/plugins/impl/fingerprint.plugin.ts
+++ b/src/plugins/impl/fingerprint.plugin.ts
@@ -26,7 +26,7 @@ export class FingerprintPlugin implements IPlugin {
      */
     public async verify(filters: VerifyFiltersDto, params: VerifyFingerprintImageDto | VerifyFingerprintTemplateDto) {
 
-        const externalIds: ExternalId[] = await this.externalIdService.fetchExternalIds(filters);
+        const externalIds: ExternalId[] = await this.externalIdService.fetchExternalIds(VerifyFiltersDto.getIds(filters));
         const dids: string = externalIds.map((externalId: ExternalId) => externalId.did).join(',');
 
         let response;

--- a/src/sms/sms.service.ts
+++ b/src/sms/sms.service.ts
@@ -35,8 +35,8 @@ export class SmsService {
      */
     public async verify(filters: VerifyFiltersDto, params: SmsParamsDto): Promise<{ status, id }> {
 
-        const externalIds: ExternalId[] = await this.externalIdService.fetchExternalIds(filters);
-        if (externalIds.length > 1) {
+        const externalIds: ExternalId[] = await this.externalIdService.fetchExternalIds(VerifyFiltersDto.getIds(filters));
+        if (externalIds.some((id: ExternalId) => id.did !== externalIds[0].did)) {
             throw new ProtocolException(ProtocolErrorCode.DUPLICATE_ENTRY, 'Provided filters did not uniquely identity a did');
         }
         const did: string = externalIds[0].did;


### PR DESCRIPTION
Summary of Changes
---
Main changes:
- Add support for roll-forward in case creating any plugins fails.
- Change VerifyFiltersDto to specify externalIds as a map of possible IDs, rather than just one ID, in order to match CreateFiltersDto.
- For both FiltersDto objects, externalIds should be an object rather than a Map<string, string>, because NestJS doesn't actually create a Map<string, string> instance for us, it only gives us an object.
- Alter one of the e2e tests to use the new externalIds filters key in order to have a test covering both the old and new filters shapes.

Some cleanup/refactoring:
- `fetchExternalIds()` now optionally throws an error if there are no results (sometimes it's valid to have no results).
- `fetchExternalIds()` now accepts a map of IDs to search for, not a FiltersDto object (which unnecessarily constrains it to only being used in some routes)
- Temporary helper functions in the FiltersDto objects to reduce some duplicated branching logic. Once we only have the `externalIds` key on filters, then this can go away. Note: it's a static function because NestJS doesn't actually give us an instance of the FiltersDto, it gives us an object. So if I made the function a member of the instance, the function wouldn't be available because NestJs didn't actually give us an instance. TLDR: typescript is really just javascript and the types it gives us are only sort of types.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>