### PR TITLE
PRO-2676: Remove static external IDs

### DIFF
--- a/src/escrow/dto/create.filters.dto.ts
+++ b/src/escrow/dto/create.filters.dto.ts
@@ -1,42 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNotEmptyObject, IsOptional } from 'class-validator';
+import { IsNotEmptyObject } from 'class-validator';
 
 export class CreateFiltersDto {
 
     @ApiProperty({
-        description: 'DEPRECATED. A hardcoded id that could be provided. Maps to type "sl_national_id".'
-    })
-    @IsOptional() @IsNotEmpty() readonly nationalId: string | undefined;
-
-    @ApiProperty({
-        description: 'DEPRECATED. A hardcoded id that could be provided. Maps to type "sl_voter_id".'
-    })
-    @IsOptional() @IsNotEmpty() readonly voterId: string | undefined;
-
-    @ApiProperty({
-        description: 'DEPRECATED. A hardcoded id that could be provided. Maps to type "sl_national_id".'
-    })
-    @IsOptional() @IsNotEmpty() readonly govId1: string | undefined;
-
-    @ApiProperty({
-        description: 'DEPRECATED. A hardcoded id that could be provided. Maps to type "sl_voter_id".'
-    })
-    @IsOptional() @IsNotEmpty() readonly govId2: string | undefined;
-
-    @ApiProperty({
         description: 'An object containing any number of IDs related to a particular DID, as long as they all refer to the same DID.'
     })
-    @IsOptional() @IsNotEmptyObject() readonly externalIds: object;
+    @IsNotEmptyObject() readonly externalIds: object;
 
-    // TODO: Remove this in favor of externalIds once we've removed the deprecated code (PRO-2676)
     public static getIds(filters: CreateFiltersDto): Map<string, string> {
-        const ids: Map<string, string> = new Map<string, string>(Object.entries(filters.externalIds ?? {}));
-        if (filters.govId1 || filters.nationalId) {
-            ids.set('sl_national_id', filters.govId1 ?? filters.nationalId);
-        }
-        if (filters.govId2 || filters.voterId) {
-            ids.set('sl_voter_id', filters.govId2 ?? filters.voterId);
-        }
-        return ids;
+        return new Map<string, string>(Object.entries(filters.externalIds));
     }
 }

--- a/src/plugins/dto/verify.filters.dto.ts
+++ b/src/plugins/dto/verify.filters.dto.ts
@@ -1,42 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNotEmptyObject, IsOptional } from 'class-validator';
+import { IsNotEmptyObject } from 'class-validator';
 
 export class VerifyFiltersDto {
 
     @ApiProperty({
-        description: 'DEPRECATED. A hardcoded id that could be provided. Maps to type "sl_national_id".'
-    })
-    @IsOptional() @IsNotEmpty() readonly nationalId: string | undefined;
-
-    @ApiProperty({
-        description: 'DEPRECATED. A hardcoded id that could be provided. Maps to type "sl_voter_id".'
-    })
-    @IsOptional() @IsNotEmpty() readonly voterId: string | undefined;
-
-    @ApiProperty({
-        description: 'DEPRECATED. A hardcoded id that could be provided. Maps to type "sl_national_id".'
-    })
-    @IsOptional() @IsNotEmpty() readonly govId1: string | undefined;
-
-    @ApiProperty({
-        description: 'DEPRECATED. A hardcoded id that could be provided. Maps to type "sl_voter_id".'
-    })
-    @IsOptional() @IsNotEmpty() readonly govId2: string | undefined;
-
-    @ApiProperty({
         description: 'An object containing any number of IDs related to a particular DID, as long as they all refer to the same DID.'
     })
-    @IsOptional() @IsNotEmptyObject() readonly externalIds: object;
+    @IsNotEmptyObject() readonly externalIds: object;
 
-    // TODO: Remove this in favor of just using externalIds once we've removed the deprecated code (PRO-2676)
-    static getIds(filters: VerifyFiltersDto): Map<string, string> {
-        const ids: Map<string, string> = new Map<string, string>(Object.entries(filters.externalIds ?? {}));
-        if (filters.govId1 || filters.nationalId) {
-            ids.set('sl_national_id', filters.govId1 ?? filters.nationalId);
-        }
-        if (filters.govId2 || filters.voterId) {
-            ids.set('sl_voter_id', filters.govId2 ?? filters.voterId);
-        }
-        return ids;
+    public static getIds(filters: VerifyFiltersDto): Map<string, string> {
+        return new Map<string, string>(Object.entries(filters.externalIds));
     }
 }

--- a/test/e2e/escrow.fingerprint.e2e-spec.ts
+++ b/test/e2e/escrow.fingerprint.e2e-spec.ts
@@ -52,7 +52,9 @@ describe('EscrowController (e2e) using fingerprint plugin', () => {
         body = {
             pluginType: 'FINGERPRINT',
             filters: {
-                govId1: 'abc123',
+                externalIds: {
+                    'sl_national_id': 'abc123'
+                }
             },
             params: {
                 position: 1,


### PR DESCRIPTION
Remove support for govId1, govId2, nationalId, and voterId. Update fingerprint e2e spec to use externalIds instead of govId1.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>