### PR TITLE
PRO-3166: Update external IDs to only accept a String or Number value.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2707,9 +2707,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.12.1.tgz",
-      "integrity": "sha512-Ne9DKPHTObRuB09Dru5AjwKjY4cJHVGu+y5f7coGn1E9Grkc3p2iBwE9AI/nJzsE29mQF7oq+mhYYRqOMFN1Bw=="
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.1.tgz",
+      "integrity": "sha512-h8VbZYnc9pDzueiS2610IULDkpFFPunHwIpl8yRwFahAEEdSpHlTy3h3z3rKq5h11CaUdBEeRViu9AYvbxiMeg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2843,9 +2843,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.59",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
-          "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg=="
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         },
         "form-data": {
           "version": "3.0.1",
@@ -3697,9 +3697,9 @@
       "dev": true
     },
     "google-libphonenumber": {
-      "version": "3.2.20",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.20.tgz",
-      "integrity": "sha512-8FANvW/lLTeXMk5M/OvhrtvJHM+IhTspMqz/5vmsw9joOwe42tvPST2mV7pKH4S8zPSbxl1sODD9hkssHL0Ocw=="
+      "version": "3.2.21",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.21.tgz",
+      "integrity": "sha512-d8dMePLPIZXHGEvyGM4PTEPBxXC29mhXtqruD11iZd9KzyKb216kJuBPZq6m3BTmiI5ZiIb4epzrZsatRJ5ZaA=="
     },
     "got": {
       "version": "9.6.0",
@@ -7210,9 +7210,9 @@
       }
     },
     "protocol-common": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/protocol-common/-/protocol-common-0.1.38.tgz",
-      "integrity": "sha512-q1tue15+No4woPpJiq4ReAK1ACr2Nu4I9KKcT4kh3oApLW/fQ7JcM+VDGDd+jZcwlR+AXt0A10IzddjriZNBxw==",
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/protocol-common/-/protocol-common-0.1.40.tgz",
+      "integrity": "sha512-utLKvfKJvF171eF7GELASKxQY5GI+XurP5h16g7tYNvdsMgTp3R0dcciUWYTaZ4Kt7Dmg62EjgWZN1FdncO0Gg==",
       "requires": {
         "@nestjs/common": "^7.6.5",
         "@nestjs/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^2.0.3",
     "pg": "^8.6.0",
-    "protocol-common": "^0.1.38",
+    "protocol-common": "^0.1.40",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.6.7",
     "swagger-ui-express": "^4.1.6",

--- a/src/escrow/dto/create.filters.dto.ts
+++ b/src/escrow/dto/create.filters.dto.ts
@@ -1,5 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmptyObject } from 'class-validator';
+import { isStringOrFail } from 'protocol-common/validation/validations/is.string';
+import { throwValidationException } from 'protocol-common/validation/common/utility/error.utility';
+import { isNumberOrFail } from 'protocol-common/validation/validations/is.number';
 
 export class CreateFiltersDto {
 
@@ -9,6 +12,17 @@ export class CreateFiltersDto {
     @IsNotEmptyObject() readonly externalIds: object;
 
     public static getIds(filters: CreateFiltersDto): Map<string, string> {
-        return new Map<string, string>(Object.entries(filters.externalIds));
+        return new Map<string, string>(Object.entries(filters.externalIds).map((entry: [string, unknown]) => {
+            try {
+                isStringOrFail(entry[1]);
+            } catch (e1) {
+                try {
+                    isNumberOrFail(entry[1]);
+                } catch (e2) {
+                    throwValidationException(['All external IDs must have either a string or numeric value']);
+                }
+            }
+            return [entry[0], `${entry[1]}`];
+        }));
     }
 }

--- a/test/e2e/escrow.sms.e2e-spec.ts
+++ b/test/e2e/escrow.sms.e2e-spec.ts
@@ -35,8 +35,8 @@ describe('EscrowController (e2e) using SMS plugin', () => {
     let app: INestApplication;
     let agentId: string;
     let otp: number;
-    let nationalId: string;
-    let voterId: string;
+    let id1: string;
+    let id2: number;
     let did: string;
     let phoneNumber: string;
     let pluginType: string;
@@ -46,8 +46,8 @@ describe('EscrowController (e2e) using SMS plugin', () => {
             pluginType,
             filters: {
                 externalIds: {
-                    sl_national_id: nationalId,
-                    sl_voter_id: voterId
+                    id_1: id1,
+                    id_2: id2
                 }
             },
             params: {
@@ -61,7 +61,7 @@ describe('EscrowController (e2e) using SMS plugin', () => {
             pluginType,
             filters: {
                 externalIds: {
-                    sl_national_id: nationalId
+                    id_1: id1
                 }
             },
             params: {
@@ -78,10 +78,10 @@ describe('EscrowController (e2e) using SMS plugin', () => {
         process.env.GLOBAL_CACHE_MAX = '1000000';
 
         // Constants for use throughout the test suite
-        voterId = `${1000000 + parseInt(now().toString().substr(7, 6), 10)}`; // Unique 7 digit number that doesn't start with 0
-        const voterIdHash = pepperHash(`${voterId}`);
-        nationalId = 'N' + voterId;
-        const nationalIdHash = pepperHash(nationalId);
+        id2 = 1000000 + parseInt(now().toString().substr(7, 6), 10); // Unique 7 digit number that doesn't start with 0
+        const voterIdHash = pepperHash(`${id2}`);
+        id1 = 'N' + id2;
+        const nationalIdHash = pepperHash(id1);
         otp = 123456;
         did = 'agentId123';
         phoneNumber = '+12025550114';
@@ -91,11 +91,11 @@ describe('EscrowController (e2e) using SMS plugin', () => {
         const mockExternalId1 = new ExternalId();
         mockExternalId1.did = did;
         mockExternalId1.external_id = nationalIdHash;
-        mockExternalId1.external_id_type = 'sl_national_id';
+        mockExternalId1.external_id_type = 'id_1';
         const mockExternalId2 = new ExternalId();
         mockExternalId2.did = did;
         mockExternalId2.external_id = voterIdHash;
-        mockExternalId2.external_id_type = 'sl_voter_id';
+        mockExternalId2.external_id_type = 'id_2';
         const mockExternalIdRepository = new class extends MockRepository<ExternalId> {
 
             externalIdFilter(externalId: ExternalId, conditions?: FindConditions<ExternalId>): boolean {
@@ -213,6 +213,18 @@ describe('EscrowController (e2e) using SMS plugin', () => {
             });
     });
 
+    it('Create endpoint fails with invalid filters', () => {
+        const data = buildCreateRequest();
+        data.filters.externalIds.id_1 = {'foo': 'bar'};
+        return request(app.getHttpServer())
+            .post('/v1/escrow/create')
+            .send(data)
+            .expect(400)
+            .then((res) => {
+                expect(res.body.code).toBe(ProtocolErrorCode.VALIDATION_EXCEPTION);
+            });
+    });
+
     it('Create endpoint succeeds with valid parameters', () => {
         const data = buildCreateRequest();
         data.params.phoneNumber = '+12025550156'; // Will be overwritten by the next test
@@ -255,7 +267,7 @@ describe('EscrowController (e2e) using SMS plugin', () => {
 
     it('Error case: Invalid ID leads to NO_CITIZEN_FOUND', () => {
         const data = buildVerifyRequest();
-        data.filters.externalIds.sl_national_id = 'BAD_ID';
+        data.filters.externalIds.id_1 = 'BAD_ID';
         return request(app.getHttpServer())
             .post('/v1/escrow/verify')
             .send(data)


### PR DESCRIPTION
* Update external IDs to only accept a String or Number value.
* Update e2e tests to reflect this requirement.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>