### PR TITLE
Remove use of ts-node from repo.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ jobs:
           name: Start docker compose and wait for readiness
           command: |
             docker network prune -f
-            docker-compose -f docker-compose.ci.yml build
+            docker-compose -f docker-compose.ci.yml build --no-cache
             set -x
-            docker-compose -f docker-compose.ci.yml up -d
+            docker-compose -f docker-compose.ci.yml up --force-recreate -d
             sleep 15
             docker-compose -f docker-compose.ci.yml logs
       - run:

--- a/package.json
+++ b/package.json
@@ -12,11 +12,8 @@
   "scripts": {
     "build": "rm -rf dist/ && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
-    "start": "ts-node -r tsconfig-paths/register -r dotenv/config src/main.ts",
+    "start": "rm -rf dist/ && tsc && node -r dotenv/config src/main.js",
     "start:debug": "nodemon --legacy-watch",
-    "prestart:prod": "rimraf dist && tsc",
-    "start:prod": "node dist/main.js",
-    "start:hmr": "node dist/server",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "lint:fix": "tslint -p tsconfig.json -c tslint.json --fix",
     "test": "node -r dotenv/config node_modules/.bin/jest --runInBand  --forceExit",
@@ -65,7 +62,6 @@
     "supertest": "^6.1.3",
     "ts-jest": "^26.5.6",
     "ts-node": "^9.1.1",
-    "tsconfig-paths": "^3.9.0",
     "tslint": "^6.1.3"
   },
   "jest": {
@@ -93,6 +89,6 @@
     "ignore": [
       "src/**/*.spec.ts"
     ],
-    "exec": "ts-node -r tsconfig-paths/register -r dotenv/config src/main.ts"
+    "exec": "tsc && node -r dotenv/config dist/main.js"
   }
 }


### PR DESCRIPTION
Resolves #74 

Summary
---
* Remove use of ts-node from repo.
* Make sure circle ci config doesn't use cached docker images or containers.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>