### PR TITLE
Add a CD step to deploy to dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,26 @@ jobs:
               exit 1;
             fi
 
+  push-to-dev:
+    machine:
+      image: ubuntu-1604:201903-01
+    parameters:
+      tag:
+        default: latest
+        description: Tag of aries-key-guardian to push to dev
+        type: string
+    steps:
+      - checkout
+      - kube-orb/install
+      - kube-orb/install-kubeconfig:
+          kubeconfig: KUBECONFIG_BASE64
+      - aws-eks/install-aws-iam-authenticator
+      - helm/install-helm-client:
+          version: v3.2.4
+      - run:
+          name: Deploy to dev cloud
+          command: helm upgrade --install aries-key-guardian helm-config --set image.tag=<<parameters.tag>>
+
 workflows:
   build-test-deploy:
     jobs:
@@ -130,7 +150,21 @@ workflows:
           dockerfile: Dockerfile.production
           image: kivaprotocol/aries-key-guardian
           tag: << pipeline.git.tag >>,latest
+      - push-to-dev:
+          context:
+            - continuous-deployment-dev
+          requires:
+            - docker/publish
+          filters: # only run for semver tagged versions
+            tags:
+              only: /^([0-9]+)\.([0-9]+)\.([0-9]+)/
+            branches:
+              ignore: /.*/
+          tag: << pipeline.git.tag >>
 
 orbs:
   node: circleci/node@4.1.0
   docker: circleci/docker@1.3.0
+  kube-orb: circleci/kubernetes@0.11.1
+  aws-eks: circleci/aws-eks@1.0.1
+  helm: circleci/helm@1.2.0


### PR DESCRIPTION
Helm charts have already been added. This change adds the Circle CI step to actually deploy the latest Aries Key Guardian image to our dev environment. It's pretty much the same [as we did for Gateway](https://github.com/kiva/protocol-gateway/pull/23).

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>