### PR TITLE
Bugfix: Npm run start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "rm -rf dist/ && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
-    "start": "rm -rf dist/ && tsc && node -r dotenv/config src/main.js",
+    "start": "rm -rf dist/ && tsc && node -r dotenv/config dist/main.js",
     "start:debug": "nodemon --legacy-watch",
     "lint": "tslint -p tsconfig-lint.json -c tslint.json",
     "lint:fix": "tslint -p tsconfig-lint.json -c tslint.json --fix",


### PR DESCRIPTION
The command `npm run start` should use the built main.js in dist/, not go looking for a main.js in src/ (which does not exist).

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>