### PR TITLE
Fix nodemon exec command to use the proper flag for node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "ignore": [
       "src/**/*.spec.ts"
     ],
-    "exec": "tsc && node -r dotenv/config --experimental-vm-modules dist/main.js"
+    "exec": "tsc && node -r dotenv/config --experimental-json-modules dist/main.js"
   }
 }


### PR DESCRIPTION
Fix nodemon exec command to use the proper flag for node.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>